### PR TITLE
Cast tensors to double to run validation

### DIFF
--- a/src/data_modules/waymo_post_processing.py
+++ b/src/data_modules/waymo_post_processing.py
@@ -100,14 +100,14 @@ class WaymoPostProcessing(nn.Module):
             waymo_scores = torch.zeros(
                 [n_scene, pred_dict["ref_idx_n"], self.k_pred], device=trajs.device, dtype=trajs.dtype
             )
-            waymo_scores[scene_indices, pred_dict["ref_idx"]] = scores  # [n_scene, n_agent, k_pred]
+            waymo_scores[scene_indices, pred_dict["ref_idx"]] = scores.double()  # [n_scene, n_agent, k_pred]
 
             waymo_valid = torch.zeros([n_scene, pred_dict["ref_idx_n"]], device=trajs.device, dtype=torch.bool)
             waymo_valid[scene_indices, pred_dict["ref_idx"]] = pred_dict["pred_valid"].squeeze(-1)
             waymo_valid = waymo_valid.unsqueeze(1).expand(-1, n_step, -1)  # [n_scene, n_step, n_agent]
         else:
             waymo_trajs = trajs.movedim(3, 1)  # [n_scene, n_step, n_agent, k_pred, 2]
-            waymo_scores = scores  # [n_scene, n_agent, k_pred]
+            waymo_scores = scores.double()  # [n_scene, n_agent, k_pred]
             waymo_valid = pred_dict["pred_valid"].unsqueeze(1).expand(-1, n_step, -1)  # [n_scene, n_step, n_agent]
 
         if pred_dict["pred_yaw_bbox"] is not None:

--- a/src/utils/transform_utils.py
+++ b/src/utils/transform_utils.py
@@ -168,7 +168,7 @@ def torch_pos2global(in_pos: Tensor, local_pos: Tensor, local_rot: Tensor) -> Te
     Returns:
         out_pos: [..., M, 2]
     """
-    return torch.matmul(in_pos, local_rot.transpose(-1, -2)) + local_pos
+    return torch.matmul(in_pos.double(), local_rot.transpose(-1, -2).double()) + local_pos.double()
 
 
 def torch_dir2local(in_dir: Tensor, local_rot: Tensor) -> Tensor:


### PR DESCRIPTION
Hi,

there seems to be an issue with data types when running your validation scripts.
The transformation function `torch_pos2global` ([issue](https://github.com/zhejz/HPTR/issues/6)) and the scores dict in the `WaymoPostProcessing` class expect double values:
```python
File ".../data_modules/waymo_post_processing.py", line 118, in forward
    waymo_scores[scene_indices, pred_dict["ref_idx"]] = scores  # [n_scene, n_agent, k_pred]
RuntimeError: Index put requires the source and destination dtypes match, got Double for the destination and Float for the source.
```
Therefore, my change casts the corresponding tensors to double.
